### PR TITLE
Upgrade airlift version and migrate from javax to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.airlift</groupId>
+        <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>68</version>
+        <version>105</version>
     </parent>
 
     <artifactId>airline</artifactId>
@@ -51,18 +51,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/src/main/java/io/airlift/airline/Accessor.java
+++ b/src/main/java/io/airlift/airline/Accessor.java
@@ -16,6 +16,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Streams.findLast;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -34,7 +36,7 @@ public class Accessor
     public Accessor(Iterable<Field> path)
     {
         requireNonNull(path, "path is null");
-        checkArgument(!Iterables.isEmpty(path), "path is empty");
+        checkArgument(stream(path).findAny().isPresent(), "path is empty");
 
         this.path = ImmutableList.copyOf(path);
         this.name = this.path.get(0).getDeclaringClass().getSimpleName() + "." +
@@ -86,7 +88,7 @@ public class Accessor
 
     public void addValues(Object commandInstance, Iterable<?> values)
     {
-        if (Iterables.isEmpty(values)) {
+        if (!stream(values).findAny().isPresent()) {
             return;
         }
 
@@ -101,7 +103,7 @@ public class Accessor
         }
         else {
             try {
-                field.set(instance, Iterables.getLast(values));
+                field.set(instance, findLast(stream(values)).get());
             }
             catch (Exception e) {
                 throw new ParseException(e, "Error setting %s for argument %s", field.getName(), name);

--- a/src/main/java/io/airlift/airline/Arguments.java
+++ b/src/main/java/io/airlift/airline/Arguments.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.FIELD;
 
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({FIELD})
+@Target(FIELD)
 public @interface Arguments
 {
     /**

--- a/src/main/java/io/airlift/airline/Cli.java
+++ b/src/main/java/io/airlift/airline/Cli.java
@@ -18,7 +18,6 @@
 
 package io.airlift.airline;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.airline.model.ArgumentsMetadata;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
 import static io.airlift.airline.ParserUtil.createInstance;
@@ -305,8 +305,8 @@ public class Cli<C>
     public static class GroupBuilder<C>
     {
         private final String name;
-        private String description = null;
-        private Class<? extends C> defaultCommand = null;
+        private String description;
+        private Class<? extends C> defaultCommand;
 
         private final List<Class<? extends C>> commands = new ArrayList<>();
 
@@ -320,7 +320,7 @@ public class Cli<C>
         {
             requireNonNull(description, "description is null");
             checkArgument(!description.isEmpty(), "description is empty");
-            Preconditions.checkState(this.description == null, "description is already set");
+            checkState(this.description == null, "description is already set");
             this.description = description;
             return this;
         }
@@ -328,7 +328,7 @@ public class Cli<C>
         public GroupBuilder<C> withDefaultCommand(Class<? extends C> defaultCommand)
         {
             requireNonNull(defaultCommand, "defaultCommand is null");
-            Preconditions.checkState(this.defaultCommand == null, "defaultCommand is already set");
+            checkState(this.defaultCommand == null, "defaultCommand is already set");
             this.defaultCommand = defaultCommand;
             return this;
         }

--- a/src/main/java/io/airlift/airline/CommandGroupUsage.java
+++ b/src/main/java/io/airlift/airline/CommandGroupUsage.java
@@ -4,8 +4,7 @@ import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.GlobalMetadata;
 import io.airlift.airline.model.OptionMetadata;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/airlift/airline/CommandSuggester.java
+++ b/src/main/java/io/airlift/airline/CommandSuggester.java
@@ -2,12 +2,7 @@ package io.airlift.airline;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.airline.model.CommandMetadata;
-import io.airlift.airline.model.OptionMetadata;
-
-import javax.inject.Inject;
-
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.transform;
+import jakarta.inject.Inject;
 
 public class CommandSuggester
         implements Suggester
@@ -19,7 +14,9 @@ public class CommandSuggester
     public Iterable<String> suggest()
     {
         ImmutableList.Builder<String> suggestions = ImmutableList.<String>builder()
-                .addAll(concat(transform(command.getCommandOptions(), OptionMetadata::getOptions)));
+                .addAll(command.getCommandOptions().stream()
+                        .flatMap(optionMetadata -> optionMetadata.getOptions().stream())
+                        .iterator());
 
         if (command.getArguments() != null) {
             suggestions.add("--");

--- a/src/main/java/io/airlift/airline/CommandUsage.java
+++ b/src/main/java/io/airlift/airline/CommandUsage.java
@@ -3,8 +3,7 @@ package io.airlift.airline;
 import io.airlift.airline.model.ArgumentsMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.OptionMetadata;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/airlift/airline/GlobalSuggester.java
+++ b/src/main/java/io/airlift/airline/GlobalSuggester.java
@@ -3,12 +3,9 @@ package io.airlift.airline;
 import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.GlobalMetadata;
-import io.airlift.airline.model.OptionMetadata;
+import jakarta.inject.Inject;
 
-import javax.inject.Inject;
-
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.concat;
 
 public class GlobalSuggester
         implements Suggester
@@ -19,10 +16,10 @@ public class GlobalSuggester
     @Override
     public Iterable<String> suggest()
     {
-        return concat(
-                transform(metadata.getCommandGroups(), CommandGroupMetadata::getName),
-                transform(metadata.getDefaultGroupCommands(), CommandMetadata::getName),
-                concat(transform(metadata.getOptions(), OptionMetadata::getOptions))
-        );
+        return () -> concat(
+                concat(
+                        metadata.getCommandGroups().stream().map(CommandGroupMetadata::getName),
+                        metadata.getDefaultGroupCommands().stream().map(CommandMetadata::getName)),
+                metadata.getOptions().stream().flatMap(option -> option.getOptions().stream())).iterator();
     }
 }

--- a/src/main/java/io/airlift/airline/GlobalUsage.java
+++ b/src/main/java/io/airlift/airline/GlobalUsage.java
@@ -4,8 +4,7 @@ import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.GlobalMetadata;
 import io.airlift.airline.model.OptionMetadata;
-
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/airlift/airline/GroupSuggester.java
+++ b/src/main/java/io/airlift/airline/GroupSuggester.java
@@ -2,12 +2,9 @@ package io.airlift.airline;
 
 import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
-import io.airlift.airline.model.OptionMetadata;
+import jakarta.inject.Inject;
 
-import javax.inject.Inject;
-
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.concat;
 
 public class GroupSuggester
         implements Suggester
@@ -18,9 +15,8 @@ public class GroupSuggester
     @Override
     public Iterable<String> suggest()
     {
-        return concat(
-                transform(group.getCommands(), CommandMetadata::getName),
-                concat(transform(group.getOptions(), OptionMetadata::getOptions))
-        );
+        return () -> concat(
+                group.getCommands().stream().map(CommandMetadata::getName),
+                group.getOptions().stream().flatMap(optionMetadata -> optionMetadata.getOptions().stream())).iterator();
     }
 }

--- a/src/main/java/io/airlift/airline/Help.java
+++ b/src/main/java/io/airlift/airline/Help.java
@@ -3,8 +3,7 @@ package io.airlift.airline;
 import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.GlobalMetadata;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/io/airlift/airline/HelpOption.java
+++ b/src/main/java/io/airlift/airline/HelpOption.java
@@ -1,8 +1,7 @@
 package io.airlift.airline;
 
 import io.airlift.airline.model.CommandMetadata;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class HelpOption
 {

--- a/src/main/java/io/airlift/airline/Option.java
+++ b/src/main/java/io/airlift/airline/Option.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.FIELD;
 
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({FIELD})
+@Target(FIELD)
 public @interface Option
 {
     /**

--- a/src/main/java/io/airlift/airline/Parser.java
+++ b/src/main/java/io/airlift/airline/Parser.java
@@ -13,10 +13,6 @@ import io.airlift.airline.model.OptionMetadata;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.collect.Iterables.find;
-
 public class Parser
 {
     private static final Pattern SHORT_OPTIONS_PATTERN = Pattern.compile("-[^-].*");
@@ -38,7 +34,10 @@ public class Parser
 
         // parse group
         if (tokens.hasNext()) {
-            CommandGroupMetadata group = find(metadata.getCommandGroups(), compose(equalTo(tokens.peek()), CommandGroupMetadata::getName), null);
+            CommandGroupMetadata group = metadata.getCommandGroups().stream()
+                    .filter(groupMeta -> tokens.peek().equals(groupMeta.getName()))
+                    .findFirst()
+                    .orElse(null);
             if (group != null) {
                 tokens.next();
                 state = state.withGroup(group).pushContext(Context.GROUP);
@@ -54,7 +53,10 @@ public class Parser
         }
 
         if (tokens.hasNext()) {
-            CommandMetadata command = find(expectedCommands, compose(equalTo(tokens.peek()), CommandMetadata::getName), null);
+            CommandMetadata command = expectedCommands.stream()
+                    .filter(groupMeta -> tokens.peek().equals(groupMeta.getName()))
+                    .findFirst()
+                    .orElse(null);
             if (command == null) {
                 while (tokens.hasNext()) {
                     state = state.withUnparsedInput(tokens.next());

--- a/src/main/java/io/airlift/airline/ParserUtil.java
+++ b/src/main/java/io/airlift/airline/ParserUtil.java
@@ -2,16 +2,22 @@ package io.airlift.airline;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Streams;
 import io.airlift.airline.model.ArgumentsMetadata;
 import io.airlift.airline.model.OptionMetadata;
 
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
 
 public class ParserUtil
 {
+    private ParserUtil()
+    {
+    }
+
     public static <T> T createInstance(Class<T> type)
     {
         if (type != null) {
@@ -53,7 +59,9 @@ public class ParserUtil
             List<?> values = parsedOptions.get(option);
             if (option.getArity() > 1 && values != null && !values.isEmpty()) {
                 // hack: flatten the collection
-                values = ImmutableList.copyOf(concat((Iterable<Iterable<Object>>) values));
+                values = stream((Iterable<Iterable<Object>>) values)
+                        .flatMap(Streams::stream)
+                        .collect(toImmutableList());
             }
             if (values != null && !values.isEmpty()) {
                 for (Accessor accessor : option.getAccessors()) {

--- a/src/main/java/io/airlift/airline/SuggestCommand.java
+++ b/src/main/java/io/airlift/airline/SuggestCommand.java
@@ -10,8 +10,7 @@ import io.airlift.airline.model.GlobalMetadata;
 import io.airlift.airline.model.MetadataLoader;
 import io.airlift.airline.model.OptionMetadata;
 import io.airlift.airline.model.SuggesterMetadata;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/io/airlift/airline/UsageHelper.java
+++ b/src/main/java/io/airlift/airline/UsageHelper.java
@@ -14,6 +14,10 @@ import static java.util.stream.Collectors.joining;
 
 public class UsageHelper
 {
+    private UsageHelper()
+    {
+    }
+
     public static final Comparator<OptionMetadata> DEFAULT_OPTION_COMPARATOR = new Comparator<OptionMetadata>()
     {
         @Override

--- a/src/main/java/io/airlift/airline/model/ArgumentsMetadata.java
+++ b/src/main/java/io/airlift/airline/model/ArgumentsMetadata.java
@@ -1,7 +1,6 @@
 package io.airlift.airline.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.airlift.airline.Accessor;
 
 import java.lang.reflect.Field;
@@ -9,6 +8,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 
 public class ArgumentsMetadata
@@ -23,7 +23,7 @@ public class ArgumentsMetadata
     {
         requireNonNull(title, "title is null");
         requireNonNull(path, "path is null");
-        checkArgument(!Iterables.isEmpty(path), "path is empty");
+        checkArgument(stream(path).findAny().isPresent(), "path is empty");
 
         this.title = title;
         this.description = description;
@@ -35,7 +35,7 @@ public class ArgumentsMetadata
     public ArgumentsMetadata(Iterable<ArgumentsMetadata> arguments)
     {
         requireNonNull(arguments, "arguments is null");
-        checkArgument(!Iterables.isEmpty(arguments), "arguments is empty");
+        checkArgument(stream(arguments).findAny().isPresent(), "arguments is empty");
 
         ArgumentsMetadata first = arguments.iterator().next();
 

--- a/src/main/java/io/airlift/airline/model/MetadataLoader.java
+++ b/src/main/java/io/airlift/airline/model/MetadataLoader.java
@@ -2,7 +2,6 @@ package io.airlift.airline.model;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import io.airlift.airline.Accessor;
 import io.airlift.airline.Arguments;
@@ -10,8 +9,7 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import io.airlift.airline.OptionType;
 import io.airlift.airline.Suggester;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -25,6 +23,10 @@ import static com.google.common.collect.Streams.stream;
 
 public class MetadataLoader
 {
+    private MetadataLoader()
+    {
+    }
+
     public static GlobalMetadata loadGlobal(String name,
             String description,
             CommandMetadata defaultCommand,
@@ -86,7 +88,7 @@ public class MetadataLoader
                 hidden, injectionMetadata.globalOptions,
                 injectionMetadata.groupOptions,
                 injectionMetadata.commandOptions,
-                Iterables.getFirst(injectionMetadata.arguments, null),
+                injectionMetadata.arguments.stream().findFirst().orElse(null),
                 injectionMetadata.metadataInjections,
                 commandType);
 

--- a/src/main/java/io/airlift/airline/model/OptionMetadata.java
+++ b/src/main/java/io/airlift/airline/model/OptionMetadata.java
@@ -1,7 +1,6 @@
 package io.airlift.airline.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.airlift.airline.Accessor;
 import io.airlift.airline.OptionType;
 
@@ -10,6 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 
 public class OptionMetadata
@@ -36,10 +36,10 @@ public class OptionMetadata
     {
         requireNonNull(optionType, "optionType is null");
         requireNonNull(options, "options is null");
-        checkArgument(!Iterables.isEmpty(options), "options is empty");
+        checkArgument(stream(options).findAny().isPresent(), "options is empty");
         requireNonNull(title, "title is null");
         requireNonNull(path, "path is null");
-        checkArgument(!Iterables.isEmpty(path), "path is empty");
+        checkArgument(stream(path).findAny().isPresent(), "path is empty");
 
         this.optionType = optionType;
         this.options = ImmutableSet.copyOf(options);
@@ -62,7 +62,7 @@ public class OptionMetadata
     public OptionMetadata(Iterable<OptionMetadata> options)
     {
         requireNonNull(options, "options is null");
-        checkArgument(!Iterables.isEmpty(options), "options is empty");
+        checkArgument(stream(options).findAny().isPresent(), "options is empty");
 
         OptionMetadata option = options.iterator().next();
 

--- a/src/test/java/io/airlift/airline/Git.java
+++ b/src/test/java/io/airlift/airline/Git.java
@@ -8,6 +8,10 @@ import static io.airlift.airline.OptionType.GLOBAL;
 
 public class Git
 {
+    private Git()
+    {
+    }
+
     public static void main(String... args)
     {
         CliBuilder<Runnable> builder = Cli.<Runnable>builder("git")

--- a/src/test/java/io/airlift/airline/Ping.java
+++ b/src/test/java/io/airlift/airline/Ping.java
@@ -1,6 +1,6 @@
 package io.airlift.airline;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Command(name = "ping", description = "network test utility")
 public class Ping

--- a/src/test/java/io/airlift/airline/TestCommand.java
+++ b/src/test/java/io/airlift/airline/TestCommand.java
@@ -45,9 +45,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.collect.Iterables.find;
 import static io.airlift.airline.TestingUtil.singleCommandParser;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -154,7 +151,10 @@ public class TestCommand
     public void repeatedArgs()
     {
         Cli<Args1> parser = singleCommandParser(Args1.class);
-        CommandMetadata command = find(parser.getMetadata().getDefaultGroupCommands(), compose(equalTo("Args1"), CommandMetadata::getName));
+        CommandMetadata command = parser.getMetadata().getDefaultGroupCommands().stream()
+                .filter(commandMeta -> "Args1".equals(commandMeta.getName()))
+                .findFirst()
+                .orElse(null);
         assertEquals(command.getAllOptions().size(), 8);
     }
 
@@ -425,6 +425,7 @@ public class TestCommand
             @Option(name = "-long")
             public long l;
         }
+
         singleCommandParser(A.class).parse("-lon", "32");
     }
 }

--- a/src/test/java/io/airlift/airline/TestGalaxyCommandLineParser.java
+++ b/src/test/java/io/airlift/airline/TestGalaxyCommandLineParser.java
@@ -2,9 +2,8 @@ package io.airlift.airline;
 
 import com.google.common.base.Joiner;
 import io.airlift.airline.Cli.CliBuilder;
+import jakarta.inject.Inject;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,7 +87,7 @@ public class TestGalaxyCommandLineParser
     public static class GlobalOptions
     {
         @Option(type = GLOBAL, name = "--debug", description = "Enable debug messages")
-        public boolean debug = false;
+        public boolean debug;
 
         @Option(type = GLOBAL, name = "--coordinator", description = "Galaxy coordinator host (overrides GALAXY_COORDINATOR)")
         public String coordinator = firstNonNull(System.getenv("GALAXY_COORDINATOR"), "http://localhost:64000");
@@ -163,7 +162,7 @@ public class TestGalaxyCommandLineParser
         }
     }
 
-    public static abstract class GalaxyCommand
+    public abstract static class GalaxyCommand
     {
         @Inject
         public GlobalOptions globalOptions = new GlobalOptions();
@@ -209,7 +208,7 @@ public class TestGalaxyCommandLineParser
     public static class InstallCommand
             extends GalaxyCommand
     {
-        @Option(name = {"--count"}, description = "Number of instances to install")
+        @Option(name = "--count", description = "Number of instances to install")
         public int count = 1;
 
         @Inject
@@ -362,10 +361,10 @@ public class TestGalaxyCommandLineParser
     public static class AgentAddCommand
             extends GalaxyCommand
     {
-        @Option(name = {"--count"}, description = "Number of agents to provision")
+        @Option(name = "--count", description = "Number of agents to provision")
         public int count = 1;
 
-        @Option(name = {"--availability-zone"}, description = "Availability zone to provision")
+        @Option(name = "--availability-zone", description = "Availability zone to provision")
         public String availabilityZone;
 
         @Arguments(usage = "[<instance-type>]", description = "Instance type to provision")

--- a/src/test/java/io/airlift/airline/TestParametersDelegate.java
+++ b/src/test/java/io/airlift/airline/TestParametersDelegate.java
@@ -1,9 +1,8 @@
 package io.airlift.airline;
 
 import com.google.common.collect.ImmutableList;
+import jakarta.inject.Inject;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +72,6 @@ public class TestParametersDelegate
     @Test
     public void delegatingSetsFieldsOnBothMainParamsAndTheDelegatedParams()
     {
-
         DelegatingSetsFieldsOnBothMainParamsAndTheDelegatedParams p = singleCommandParser(DelegatingSetsFieldsOnBothMainParamsAndTheDelegatedParams.class)
                 .parse("command", "-c", "--long-d", "123", "--long-b", "bValue");
         assertFalse(p.isA);
@@ -177,7 +175,6 @@ public class TestParametersDelegate
     @Test
     public void nullDelegatesAreAllowed()
     {
-
         NullDelegatesAreProhibited value = singleCommandParser(NullDelegatesAreProhibited.class).parse("command", "-a");
         assertEquals(value.delegate.a, true);
     }

--- a/src/test/java/io/airlift/airline/TestSingleCommand.java
+++ b/src/test/java/io/airlift/airline/TestSingleCommand.java
@@ -37,18 +37,14 @@ import io.airlift.airline.args.OptionsRequired;
 import io.airlift.airline.command.CommandAdd;
 import io.airlift.airline.command.CommandCommit;
 import io.airlift.airline.model.CommandMetadata;
+import jakarta.inject.Inject;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.collect.Iterables.find;
 import static io.airlift.airline.SingleCommand.singleCommand;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -130,7 +126,10 @@ public class TestSingleCommand
     public void repeatedArgs()
     {
         SingleCommand<Args1> parser = singleCommand(Args1.class);
-        CommandMetadata command = find(ImmutableList.of(parser.getCommandMetadata()), compose(equalTo("Args1"), CommandMetadata::getName));
+        CommandMetadata command = ImmutableList.of(parser.getCommandMetadata()).stream()
+                .filter(commandMeta -> "Args1".equals(commandMeta.getName()))
+                .findFirst()
+                .orElse(null);
         assertEquals(command.getAllOptions().size(), 8);
     }
 
@@ -379,6 +378,7 @@ public class TestSingleCommand
             @Option(name = "-long")
             public long l;
         }
+
         singleCommand(A.class).parse("32");
     }
 

--- a/src/test/java/io/airlift/airline/TestingUtil.java
+++ b/src/test/java/io/airlift/airline/TestingUtil.java
@@ -2,6 +2,10 @@ package io.airlift.airline;
 
 public class TestingUtil
 {
+    private TestingUtil()
+    {
+    }
+
     public static <T> Cli<T> singleCommandParser(Class<T> commandClass)
     {
         return Cli.<T>builder("parser")

--- a/src/test/java/io/airlift/airline/args/Args1.java
+++ b/src/test/java/io/airlift/airline/args/Args1.java
@@ -40,7 +40,7 @@ public class Args1
     public String groups;
 
     @Option(name = "-debug", description = "Debug mode")
-    public boolean debug = false;
+    public boolean debug;
 
     @Option(name = "-long", description = "A long number")
     public long l;

--- a/src/test/java/io/airlift/airline/args/Args2.java
+++ b/src/test/java/io/airlift/airline/args/Args2.java
@@ -38,7 +38,7 @@ public class Args2
     public String groups;
 
     @Option(name = "-debug", description = "Debug mode")
-    public boolean debug = false;
+    public boolean debug;
 
     @Option(name = "-host", description = "The host")
     public List<String> hosts = new ArrayList<>();

--- a/src/test/java/io/airlift/airline/args/ArgsArityString.java
+++ b/src/test/java/io/airlift/airline/args/ArgsArityString.java
@@ -32,7 +32,6 @@ import java.util.List;
 @Command(name = "ArgsArityString")
 public class ArgsArityString
 {
-
     @Option(name = "-pairs", arity = 2, description = "Pairs")
     public List<String> pairs;
 

--- a/src/test/java/io/airlift/airline/args/ArgsDefault.java
+++ b/src/test/java/io/airlift/airline/args/ArgsDefault.java
@@ -36,7 +36,7 @@ public class ArgsDefault
     public String groups;
 
     @Option(name = "-debug", description = "Debug mode")
-    public boolean debug = false;
+    public boolean debug;
 
     @Option(name = "-level", description = "A long number")
     public long level;

--- a/src/test/java/io/airlift/airline/args/ArgsEnum.java
+++ b/src/test/java/io/airlift/airline/args/ArgsEnum.java
@@ -29,7 +29,6 @@ import io.airlift.airline.Option;
 @Command(name = "ArgsEnum")
 public class ArgsEnum
 {
-
     public enum ChoiceType
     {
         ONE, TWO, THREE
@@ -38,5 +37,3 @@ public class ArgsEnum
     @Option(name = "-choice", description = "Choice parameter")
     public ChoiceType choice = ChoiceType.ONE;
 }
-
-

--- a/src/test/java/io/airlift/airline/args/ArgsSingleChar.java
+++ b/src/test/java/io/airlift/airline/args/ArgsSingleChar.java
@@ -31,32 +31,32 @@ public class ArgsSingleChar
     @Arguments
     public List<String> parameters = new ArrayList<>();
 
-    @Option(name = {"-l"}, description = "Long")
-    public boolean l = false;
+    @Option(name = "-l", description = "Long")
+    public boolean l;
 
     @Option(name = "-g", description = "Global")
-    public boolean g = false;
+    public boolean g;
 
     @Option(name = "-d", description = "Debug mode")
-    public boolean d = false;
+    public boolean d;
 
     @Option(name = "-s", description = "A string")
-    public String s = null;
+    public String s;
 
     @Option(name = "-p", description = "A path")
-    public String p = null;
+    public String p;
 
     @Option(name = "-n", description = "No action")
-    public boolean n = false;
+    public boolean n;
 
     @Option(name = "-2", description = "Two")
-    public boolean two = false;
+    public boolean two;
 
     @Option(name = "-f", description = "A filename")
-    public String f = null;
+    public String f;
 
     @Option(name = "-z", description = "Compress")
-    public boolean z = false;
+    public boolean z;
 
     @Option(name = "--D", description = "Directory")
     public String dir;

--- a/src/test/java/io/airlift/airline/args/CommandLineArgs.java
+++ b/src/test/java/io/airlift/airline/args/CommandLineArgs.java
@@ -28,7 +28,6 @@ import java.util.List;
 @Command(name = "CommandLineArgs")
 public class CommandLineArgs
 {
-
     @Arguments(description = "The XML suite files to run")
     public List<String> suiteFiles = new ArrayList<>();
 

--- a/src/test/java/io/airlift/airline/command/CommandAdd.java
+++ b/src/test/java/io/airlift/airline/command/CommandAdd.java
@@ -21,8 +21,7 @@ package io.airlift.airline.command;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.List;
 

--- a/src/test/java/io/airlift/airline/command/CommandCommit.java
+++ b/src/test/java/io/airlift/airline/command/CommandCommit.java
@@ -21,8 +21,7 @@ package io.airlift.airline.command;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.List;
 


### PR DESCRIPTION
These changes are necessary for presto cli to function with the JDK upgrade. Airline parses `@Inject`  annotations for composition, currently it is only picking up on javax injects, this change allows it to pick up on the jakarta inject annotation which presto is migrating to.

Most of these changes are to adhere to the checkstyle differences that come with upgraded airlift.